### PR TITLE
Hr 140 update build file to auto set encoding

### DIFF
--- a/.github/workflows/unity-build-to-azure.yml
+++ b/.github/workflows/unity-build-to-azure.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: Build
-          path: build
+          path: ${{ github.workspace }}/build
           
 # UPLOAD BUILD TO AZURE CONTAINER
   upload:
@@ -74,15 +74,53 @@ jobs:
         with:
           name: Build
           path: build
+  
+      - uses: azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
       - name: List files
         run: ls -R
         working-directory: build
-
-      # Upload to azure blob storage 
-      - uses: bacongobbler/azure-blob-storage-upload@main
+        
+      - name: Upload data to blob storage
+        uses: azure/CLI@v1
         with:
-          source_dir: build
-          container_name: test-model-viewer-build
-          connection_string: ${{ secrets.BLOB_CONNECTION_STRING }}
-          extra_args: --content-encoding gzip
-          overwrite: 'true'
+          inlineScript: |
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.data.gz --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.data.gz --content-encoding gzip
+      
+      - name: Upload framework to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.framework.js.gz --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.framework.js.gz --content-encoding gzip
+
+      - name: Upload loader to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.loader.js --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.loader.js
+
+      - name: Upload wasm to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.wasm.gz --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.wasm.gz --content-encoding gzip 
+
+      - name: Upload StreamingAssets to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+              az storage blob upload-batch --destination test-model-viewer-build --account-name unityviewerbuild --destination-path WebGL/WebGL/StreamingAssets --source ./build/WebGL/WebGL/StreamingAssets
+
+      - name: Upload TemplateData to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+              az storage blob upload-batch --destination test-model-viewer-build --account-name unityviewerbuild --destination-path WebGL/WebGL/TemplateData --source ./build/WebGL/WebGL/TemplateData
+      
+      - name: Upload index to blob storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+              az storage blob upload -f ./build/WebGL/WebGL/index.html --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/index.html

--- a/.github/workflows/unity-build-to-azure.yml
+++ b/.github/workflows/unity-build-to-azure.yml
@@ -87,40 +87,40 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.data.gz --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.data.gz --content-encoding gzip
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.data.gz --account-name unityviewerbuild --container-name model-viewer-build --name WebGL/WebGL/Build/WebGL.data.gz --content-encoding gzip
       
       - name: Upload framework to blob storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.framework.js.gz --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.framework.js.gz --content-encoding gzip
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.framework.js.gz --account-name unityviewerbuild --container-name model-viewer-build --name WebGL/WebGL/Build/WebGL.framework.js.gz --content-encoding gzip
 
       - name: Upload loader to blob storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.loader.js --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.loader.js
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.loader.js --account-name unityviewerbuild --container-name model-viewer-build --name WebGL/WebGL/Build/WebGL.loader.js
 
       - name: Upload wasm to blob storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.wasm.gz --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/Build/WebGL.wasm.gz --content-encoding gzip 
+              az storage blob upload -f ./build/WebGL/WebGL/Build/WebGL.wasm.gz --account-name unityviewerbuild --container-name model-viewer-build --name WebGL/WebGL/Build/WebGL.wasm.gz --content-encoding gzip 
 
       - name: Upload StreamingAssets to blob storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload-batch --destination test-model-viewer-build --account-name unityviewerbuild --destination-path WebGL/WebGL/StreamingAssets --source ./build/WebGL/WebGL/StreamingAssets
+              az storage blob upload-batch --destination model-viewer-build --account-name unityviewerbuild --destination-path WebGL/WebGL/StreamingAssets --source ./build/WebGL/WebGL/StreamingAssets
 
       - name: Upload TemplateData to blob storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload-batch --destination test-model-viewer-build --account-name unityviewerbuild --destination-path WebGL/WebGL/TemplateData --source ./build/WebGL/WebGL/TemplateData
+              az storage blob upload-batch --destination model-viewer-build --account-name unityviewerbuild --destination-path WebGL/WebGL/TemplateData --source ./build/WebGL/WebGL/TemplateData
       
       - name: Upload index to blob storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
-              az storage blob upload -f ./build/WebGL/WebGL/index.html --account-name unityviewerbuild --container-name test-model-viewer-build --name WebGL/WebGL/index.html
+              az storage blob upload -f ./build/WebGL/WebGL/index.html --account-name unityviewerbuild --container-name model-viewer-build --name WebGL/WebGL/index.html


### PR DESCRIPTION
the yml file is now updated to automatically encode the files with gzip, checkout [test-model-viewer-build](https://portal.azure.com/#view/Microsoft_Azure_Storage/ContainerMenuBlade/~/overview/storageAccountId/%2Fsubscriptions%2Fa2f6cb3c-7458-4872-8099-fcd096f29d7f%2FresourceGroups%2FUnity-Model-Viewer%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Funityviewerbuild/path/test-model-viewer-build/etag/%220x8DB948A998F3D87%22/defaultEncryptionScope/%24account-encryption-key/denyEncryptionScopeOverride~/false/defaultId//publicAccessVal/Container) for reference.

Please message me when merging as GitHub secret will need some update for this new version to work 